### PR TITLE
Add null check to avoid TypeError

### DIFF
--- a/module/graph/module.py
+++ b/module/graph/module.py
@@ -418,7 +418,7 @@ def plot(i):
                    if v!=None and v<tmin[d]: tmin[d]=v
                    if v!=None and v>tmax[d]: tmax[d]=v 
 
-                if len(stmin[g])<=d:
+                if len(stmin[g])<=d and v!=None:
                    stmin[g].append(v)
                    stmax[g].append(v)
                 else:


### PR DESCRIPTION
fix this bug：
$ bash use_ml_to_predict_compiler_flags_local.bat
Traceback (most recent call last):
  File "/media/B/git/ck/ck/kernel.py", line 9615, in <module>
    r=access(sys.argv[1:])
  File "/media/B/git/ck/ck/kernel.py", line 9571, in access
    rr=perform_action(i)
  File "/media/B/git/ck/ck/kernel.py", line 3461, in perform_action
    return a(i)
  File "/media/B/tsp/CK/ck-analytics/module/advice/module.py", line 341, in ask
    rr=ck.access(ii)
  File "/media/B/git/ck/ck/kernel.py", line 9571, in access
    rr=perform_action(i)
  File "/media/B/git/ck/ck/kernel.py", line 3461, in perform_action
    return a(i)
  File "/media/B/tsp/CK/reproduce-milepost-project/module/milepost/module.py", line 426, in show
    r=ck.access(ii)
  File "/media/B/git/ck/ck/kernel.py", line 9571, in access
    rr=perform_action(i)
  File "/media/B/git/ck/ck/kernel.py", line 3461, in perform_action
    return a(i)
  File "/media/B/tsp/CK/ck-crowdtuning/module/experiment.tune.compiler.flags.gcc.e/module.py", line 58, in html_viewer
    return ck.access(i)
  File "/media/B/git/ck/ck/kernel.py", line 9571, in access
    rr=perform_action(i)
  File "/media/B/git/ck/ck/kernel.py", line 3461, in perform_action
    return a(i)
  File "/media/B/tsp/CK/ck-crowdtuning/module/experiment.tune.compiler.flags/module.py", line 786, in html_viewer
    r=ck.access(ii)
  File "/media/B/git/ck/ck/kernel.py", line 9571, in access
    rr=perform_action(i)
  File "/media/B/git/ck/ck/kernel.py", line 3461, in perform_action
    return a(i)
  File "/media/B/tsp/CK/ck-analytics/module/graph/module.py", line 425, in plot
    if v!=None and v<stmin[g][d]: stmin[g][d]=v
TypeError: '<' not supported between instances of 'float' and 'NoneType'