### PR TITLE
Minor condition check improvment

### DIFF
--- a/module/math.conditions/module.py
+++ b/module/math.conditions/module.py
@@ -111,7 +111,7 @@ def check(i):
 
                   dv=behavior.get(kt,None)
 
-                  s='         - Condition on "'+kt+'" : '
+                  s='         - Condition on "'+kt+' '+str(x)+' '+str(y)+'" : '
 
                   if dv==None:
                      fine=False


### PR DESCRIPTION
The print information is now:

Check extra conditions on results ...

         - Condition on "##characteristics#run#execution_time_kernel_0#min_imp" : FAILED (1.0460671442267968)

To understand it, we need to query the JSON file.
So, we may print the complete conditions to enhance readability:

Check extra conditions on results ...

         - Condition on "##characteristics#run#execution_time_kernel_0#min_imp > 1.09" : FAILED (1.0460671442267968)